### PR TITLE
Fix CORS header method in Google Apps Script

### DIFF
--- a/google_app_script.gs
+++ b/google_app_script.gs
@@ -17,17 +17,13 @@ function doPost(e) {
     return ContentService
       .createTextOutput(JSON.stringify({ status: "success" }))
       .setMimeType(ContentService.MimeType.JSON)
-      .setHeaders({
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "POST"
-      });
+      .setHeader("Access-Control-Allow-Origin", "*")
+      .setHeader("Access-Control-Allow-Methods", "POST");
 
   } catch (error) {
     return ContentService
       .createTextOutput(JSON.stringify({ status: "error", message: error.message }))
       .setMimeType(ContentService.MimeType.JSON)
-      .setHeaders({
-        "Access-Control-Allow-Origin": "*"
-      });
+      .setHeader("Access-Control-Allow-Origin", "*");
   }
 }


### PR DESCRIPTION
## Summary
- use `setHeader` (singular) for CORS headers in Google Apps Script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f6ba0e69883289db411e490f40933