### PR TITLE
Handle CORS preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Serve `index.html`, `script.js` and `styles.css` from any static host (GitHub Pa
 
 - The CSV links used in `loadDropdowns` and `loadProducts` should point to the published CSV exports of your Sheets.
 - The URL passed to `fetch` inside `submitForm` should be the web app URL from your deployed Apps Script.
+- Avoid setting a custom `Content-Type` header in the `fetch` call so that the
+  request is treated as a **simple request**. This prevents CORS preflight issues
+  when posting data to the Apps Script.
 
 Once these values are configured the form will send submissions directly to your spreadsheet.
 

--- a/script.js
+++ b/script.js
@@ -124,7 +124,6 @@ function submitForm() {
   }
   fetch("https://script.google.com/macros/s/AKfycbwTTKahHaWxeODCJ2SmXMXxpRJfh9zeWHJjuEgLc4ZkMovWk-VZ3xiszTEUBFRlD1RZMg/exec", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(entries)
   })
   .then(res => res.json())


### PR DESCRIPTION
## Summary
- avoid sending a custom `Content-Type` header when posting data
- document why the fetch request should omit the header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686f6e7406f483289ab4b8b97931735e