### PR TITLE
Add Laravel API scaffolding

### DIFF
--- a/app/app/Http/Controllers/Api/V1/ActiveMonthYearController.php
+++ b/app/app/Http/Controllers/Api/V1/ActiveMonthYearController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\ActiveMonthYear;
+
+class ActiveMonthYearController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return ActiveMonthYear::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'year' => 'required|integer',
+            'month' => 'required|integer',
+            'is_open' => 'boolean',
+        ]);
+        return ActiveMonthYear::create($data);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        return ActiveMonthYear::findOrFail($id);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $period = ActiveMonthYear::findOrFail($id);
+        $data = $request->validate([
+            'year' => 'sometimes|integer',
+            'month' => 'sometimes|integer',
+            'is_open' => 'boolean',
+        ]);
+        $period->update($data);
+        return $period;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $period = ActiveMonthYear::findOrFail($id);
+        $period->delete();
+        return response()->noContent();
+    }
+}

--- a/app/app/Http/Controllers/Api/V1/CategoryController.php
+++ b/app/app/Http/Controllers/Api/V1/CategoryController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Category;
+
+class CategoryController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return Category::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'category_code' => 'required',
+            'name' => 'required',
+            'supplier_id' => 'required|exists:suppliers,id',
+        ]);
+        return Category::create($data);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        return Category::findOrFail($id);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $category = Category::findOrFail($id);
+        $data = $request->validate([
+            'category_code' => 'sometimes|required',
+            'name' => 'sometimes|required',
+            'supplier_id' => 'sometimes|exists:suppliers,id',
+        ]);
+        $category->update($data);
+        return $category;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $category = Category::findOrFail($id);
+        $category->delete();
+        return response()->noContent();
+    }
+}

--- a/app/app/Http/Controllers/Api/V1/ChannelController.php
+++ b/app/app/Http/Controllers/Api/V1/ChannelController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Channel;
+
+class ChannelController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return Channel::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'channel_code' => 'required|unique:channels,channel_code',
+            'name' => 'required',
+            'region_id' => 'required|exists:regions,id',
+            'is_active' => 'boolean',
+        ]);
+        return Channel::create($data);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        return Channel::findOrFail($id);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $channel = Channel::findOrFail($id);
+        $data = $request->validate([
+            'channel_code' => 'sometimes|required|unique:channels,channel_code,'.$channel->id,
+            'name' => 'sometimes|required',
+            'region_id' => 'sometimes|exists:regions,id',
+            'is_active' => 'boolean',
+        ]);
+        $channel->update($data);
+        return $channel;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $channel = Channel::findOrFail($id);
+        $channel->delete();
+        return response()->noContent();
+    }
+}

--- a/app/app/Http/Controllers/Api/V1/DependencyController.php
+++ b/app/app/Http/Controllers/Api/V1/DependencyController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Channel;
+use App\Models\Salesman;
+use App\Models\Category;
+
+class DependencyController extends Controller
+{
+    public function channels(Request $request)
+    {
+        $request->validate(['region_id' => 'required|exists:regions,id']);
+        return Channel::where('region_id', $request->region_id)->get();
+    }
+
+    public function salesmen(Request $request)
+    {
+        $request->validate([
+            'region_id' => 'required|exists:regions,id',
+            'channel_id' => 'required|exists:channels,id',
+        ]);
+        return Salesman::where('region_id', $request->region_id)
+            ->where('channel_id', $request->channel_id)
+            ->get();
+    }
+
+    public function categories(Request $request)
+    {
+        $request->validate(['supplier_id' => 'required|exists:suppliers,id']);
+        return Category::where('supplier_id', $request->supplier_id)->get();
+    }
+}

--- a/app/app/Http/Controllers/Api/V1/SalesTargetController.php
+++ b/app/app/Http/Controllers/Api/V1/SalesTargetController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\SalesTarget;
+
+class SalesTargetController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $this->authorize('viewAny', SalesTarget::class);
+        return SalesTarget::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $this->authorize('create', SalesTarget::class);
+        $data = $request->validate([
+            'year' => 'required|integer',
+            'month' => 'required|integer',
+            'region_id' => 'required|exists:regions,id',
+            'channel_id' => 'required|exists:channels,id',
+            'salesman_id' => 'required|exists:salesmen,id',
+            'supplier_id' => 'required|exists:suppliers,id',
+            'category_id' => 'required|exists:categories,id',
+            'amount' => 'required|numeric',
+            'notes' => 'nullable',
+        ]);
+        return SalesTarget::create($data);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        $target = SalesTarget::findOrFail($id);
+        $this->authorize('view', $target);
+        return $target;
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $target = SalesTarget::findOrFail($id);
+        $this->authorize('update', $target);
+        $data = $request->validate([
+            'year' => 'sometimes|integer',
+            'month' => 'sometimes|integer',
+            'region_id' => 'sometimes|exists:regions,id',
+            'channel_id' => 'sometimes|exists:channels,id',
+            'salesman_id' => 'sometimes|exists:salesmen,id',
+            'supplier_id' => 'sometimes|exists:suppliers,id',
+            'category_id' => 'sometimes|exists:categories,id',
+            'amount' => 'sometimes|numeric',
+            'notes' => 'nullable',
+        ]);
+        $target->update($data);
+        return $target;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $target = SalesTarget::findOrFail($id);
+        $this->authorize('delete', $target);
+        $target->delete();
+        return response()->noContent();
+    }
+}

--- a/app/app/Http/Controllers/Api/V1/SalesmanController.php
+++ b/app/app/Http/Controllers/Api/V1/SalesmanController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Salesman;
+
+class SalesmanController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return Salesman::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'employee_code' => 'required|unique:salesmen,employee_code',
+            'salesman_code' => 'nullable',
+            'name' => 'required',
+            'region_id' => 'required|exists:regions,id',
+            'channel_id' => 'required|exists:channels,id',
+            'classification' => 'required|in:food,non_food,both',
+        ]);
+        return Salesman::create($data);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        return Salesman::findOrFail($id);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $salesman = Salesman::findOrFail($id);
+        $data = $request->validate([
+            'employee_code' => 'sometimes|required|unique:salesmen,employee_code,'.$salesman->id,
+            'salesman_code' => 'nullable',
+            'name' => 'sometimes|required',
+            'region_id' => 'sometimes|exists:regions,id',
+            'channel_id' => 'sometimes|exists:channels,id',
+            'classification' => 'sometimes|in:food,non_food,both',
+        ]);
+        $salesman->update($data);
+        return $salesman;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $salesman = Salesman::findOrFail($id);
+        $salesman->delete();
+        return response()->noContent();
+    }
+}

--- a/app/app/Http/Controllers/Api/V1/SupplierController.php
+++ b/app/app/Http/Controllers/Api/V1/SupplierController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Supplier;
+
+class SupplierController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return Supplier::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'supplier_code' => 'required|unique:suppliers,supplier_code',
+            'name' => 'required',
+            'classification' => 'required|in:food,non_food',
+        ]);
+        return Supplier::create($data);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        return Supplier::findOrFail($id);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $supplier = Supplier::findOrFail($id);
+        $data = $request->validate([
+            'supplier_code' => 'sometimes|required|unique:suppliers,supplier_code,'.$supplier->id,
+            'name' => 'sometimes|required',
+            'classification' => 'sometimes|in:food,non_food',
+        ]);
+        $supplier->update($data);
+        return $supplier;
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $supplier = Supplier::findOrFail($id);
+        $supplier->delete();
+        return response()->noContent();
+    }
+}

--- a/app/app/Policies/SalesTargetPolicy.php
+++ b/app/app/Policies/SalesTargetPolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\SalesTarget;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class SalesTargetPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, SalesTarget $salesTarget): bool
+    {
+        return $user->role === 'admin' ||
+            ($user->role === 'manager' &&
+                $user->region_id == $salesTarget->region_id &&
+                $user->channel_id == $salesTarget->channel_id);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return in_array($user->role, ['admin', 'manager']);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, SalesTarget $salesTarget): bool
+    {
+        return $this->view($user, $salesTarget);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, SalesTarget $salesTarget): bool
+    {
+        return $this->view($user, $salesTarget);
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, SalesTarget $salesTarget): bool
+    {
+        return $this->view($user, $salesTarget);
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, SalesTarget $salesTarget): bool
+    {
+        return $user->role === 'admin';
+    }
+}

--- a/app/app/Providers/AuthServiceProvider.php
+++ b/app/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+use App\Models\SalesTarget;
+use App\Policies\SalesTargetPolicy;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        Gate::policy(SalesTarget::class, SalesTargetPolicy::class);
+    }
+}

--- a/app/bootstrap/app.php
+++ b/app/bootstrap/app.php
@@ -3,8 +3,12 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use App\Providers\AuthServiceProvider;
 
 return Application::configure(basePath: dirname(__DIR__))
+    ->withProviders([
+        App\Providers\AuthServiceProvider::class,
+    ])
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         commands: __DIR__.'/../routes/console.php',

--- a/app/bootstrap/providers.php
+++ b/app/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -3,6 +3,13 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\RegionController;
+use App\Http\Controllers\Api\V1\ChannelController;
+use App\Http\Controllers\Api\V1\SalesmanController;
+use App\Http\Controllers\Api\V1\SupplierController;
+use App\Http\Controllers\Api\V1\CategoryController;
+use App\Http\Controllers\Api\V1\ActiveMonthYearController;
+use App\Http\Controllers\Api\V1\SalesTargetController;
+use App\Http\Controllers\Api\V1\DependencyController;
 
 Route::prefix('v1')->group(function () {
     Route::get('/auth/me', [AuthController::class, 'me']);
@@ -10,4 +17,14 @@ Route::prefix('v1')->group(function () {
     Route::post('/auth/logout', [AuthController::class, 'logout']);
 
     Route::apiResource('regions', RegionController::class);
+    Route::apiResource('channels', ChannelController::class);
+    Route::apiResource('salesmen', SalesmanController::class);
+    Route::apiResource('suppliers', SupplierController::class);
+    Route::apiResource('categories', CategoryController::class);
+    Route::apiResource('periods', ActiveMonthYearController::class);
+    Route::apiResource('targets', SalesTargetController::class);
+
+    Route::get('/deps/channels', [DependencyController::class, 'channels']);
+    Route::get('/deps/salesmen', [DependencyController::class, 'salesmen']);
+    Route::get('/deps/categories', [DependencyController::class, 'categories']);
 });


### PR DESCRIPTION
## Summary
- implement controllers for core entities (channels, salesmen, suppliers, categories, periods, targets)
- wire up dependency endpoints and resources
- add `SalesTargetPolicy` and register through new `AuthServiceProvider`
- configure service provider bootstrapping

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_688930153c948328af8f3c72d473821f