### PR TITLE
Implement manager scope and period patch endpoint

### DIFF
--- a/app/app/Http/Controllers/Api/V1/ActiveMonthYearController.php
+++ b/app/app/Http/Controllers/Api/V1/ActiveMonthYearController.php
@@ -11,9 +11,13 @@ class ActiveMonthYearController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
-        return ActiveMonthYear::all();
+        $query = ActiveMonthYear::query();
+        if ($request->filled('is_open')) {
+            $query->where('is_open', $request->boolean('is_open'));
+        }
+        return $query->get();
     }
 
     /**
@@ -60,5 +64,15 @@ class ActiveMonthYearController extends Controller
         $period = ActiveMonthYear::findOrFail($id);
         $period->delete();
         return response()->noContent();
+    }
+
+    public function patchYearMonth(string $year, string $month, Request $request)
+    {
+        $period = ActiveMonthYear::where('year', $year)->where('month', $month)->firstOrFail();
+        $data = $request->validate([
+            'is_open' => 'required|boolean',
+        ]);
+        $period->update($data);
+        return $period;
     }
 }

--- a/app/app/Http/Controllers/Api/V1/SalesTargetController.php
+++ b/app/app/Http/Controllers/Api/V1/SalesTargetController.php
@@ -5,16 +5,52 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
 use App\Models\SalesTarget;
+use App\Models\ActiveMonthYear;
+use App\Models\Salesman;
 
 class SalesTargetController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Request $request)
     {
         $this->authorize('viewAny', SalesTarget::class);
-        return SalesTarget::all();
+
+        $query = SalesTarget::query();
+
+        if ($request->filled('year')) {
+            $query->where('year', $request->year);
+        }
+        if ($request->filled('month')) {
+            $query->where('month', $request->month);
+        }
+        if ($request->filled('region_id')) {
+            $query->where('region_id', $request->region_id);
+        }
+        if ($request->filled('channel_id')) {
+            $query->where('channel_id', $request->channel_id);
+        }
+        if ($request->filled('supplier_id')) {
+            $query->where('supplier_id', $request->supplier_id);
+        }
+        if ($request->filled('category_id')) {
+            $query->where('category_id', $request->category_id);
+        }
+
+        if ($request->filled('employee_code')) {
+            $query->whereHas('salesman', function ($q) use ($request) {
+                $q->where('employee_code', $request->employee_code);
+            });
+        }
+
+        $user = $request->user();
+        if ($user->role === 'manager') {
+            $query->where('region_id', $user->region_id)
+                  ->where('channel_id', $user->channel_id);
+        }
+
+        return $query->get();
     }
 
     /**
@@ -23,6 +59,7 @@ class SalesTargetController extends Controller
     public function store(Request $request)
     {
         $this->authorize('create', SalesTarget::class);
+
         $data = $request->validate([
             'year' => 'required|integer',
             'month' => 'required|integer',
@@ -34,6 +71,32 @@ class SalesTargetController extends Controller
             'amount' => 'required|numeric',
             'notes' => 'nullable',
         ]);
+
+        $user = $request->user();
+        if ($user->role === 'manager' && ($user->region_id != $data['region_id'] || $user->channel_id != $data['channel_id'])) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $periodOpen = ActiveMonthYear::where('year', $data['year'])
+            ->where('month', $data['month'])
+            ->where('is_open', true)
+            ->exists();
+
+        if (!$periodOpen) {
+            return response()->json(['message' => 'Period is closed'], 422);
+        }
+
+        $exists = SalesTarget::where('year', $data['year'])
+            ->where('month', $data['month'])
+            ->where('salesman_id', $data['salesman_id'])
+            ->where('supplier_id', $data['supplier_id'])
+            ->where('category_id', $data['category_id'])
+            ->exists();
+
+        if ($exists) {
+            return response()->json(['message' => 'Target already exists'], 422);
+        }
+
         return SalesTarget::create($data);
     }
 
@@ -65,6 +128,18 @@ class SalesTargetController extends Controller
             'amount' => 'sometimes|numeric',
             'notes' => 'nullable',
         ]);
+
+        $user = $request->user();
+        if ($user->role === 'manager' && (($request->has('region_id') && $user->region_id != $request->region_id) || ($request->has('channel_id') && $user->channel_id != $request->channel_id))) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        if (($request->has('year') || $request->has('month')) && !ActiveMonthYear::where('year', $request->get('year', $target->year))
+            ->where('month', $request->get('month', $target->month))
+            ->where('is_open', true)->exists()) {
+            return response()->json(['message' => 'Period is closed'], 422);
+        }
+
         $target->update($data);
         return $target;
     }

--- a/app/app/Policies/SalesTargetPolicy.php
+++ b/app/app/Policies/SalesTargetPolicy.php
@@ -13,7 +13,7 @@ class SalesTargetPolicy
      */
     public function viewAny(User $user): bool
     {
-        return true;
+        return in_array($user->role, ['admin', 'manager']);
     }
 
     /**

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -22,6 +22,7 @@ Route::prefix('v1')->group(function () {
     Route::apiResource('suppliers', SupplierController::class);
     Route::apiResource('categories', CategoryController::class);
     Route::apiResource('periods', ActiveMonthYearController::class);
+    Route::patch('periods/{year}/{month}', [ActiveMonthYearController::class, 'patchYearMonth']);
     Route::apiResource('targets', SalesTargetController::class);
 
     Route::get('/deps/channels', [DependencyController::class, 'channels']);


### PR DESCRIPTION
## Summary
- filter SalesTarget list by query parameters and manager scope
- validate period is open and uniqueness when creating/updating targets
- restrict manager updates to their region/channel
- filter periods by `is_open` and add endpoint to patch periods by year/month
- update policy and routes

## Testing
- `composer install --no-interaction --no-progress`
- `php artisan key:generate`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6889956d126483288f66c72903d647c4