### PR TITLE
Implement bulk targets and seed data

### DIFF
--- a/app/database/factories/UserFactory.php
+++ b/app/database/factories/UserFactory.php
@@ -24,9 +24,11 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'username' => fake()->unique()->userName(),
             'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
+            'role' => 'manager',
+            'region_id' => null,
+            'channel_id' => null,
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];

--- a/app/database/migrations/2025_07_29_202134_create_channels_table.php
+++ b/app/database/migrations/2025_07_29_202134_create_channels_table.php
@@ -13,6 +13,7 @@ return new class extends Migration
     {
         Schema::create('channels', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('region_id')->constrained()->cascadeOnDelete();
             $table->string('channel_code')->unique();
             $table->string('name');
             $table->boolean('is_active')->default(true);

--- a/app/database/seeders/DatabaseSeeder.php
+++ b/app/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,8 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use App\Models\Region;
+use App\Models\Channel;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -13,11 +15,31 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $region = Region::create([
+            'region_code' => 'R1',
+            'name' => 'Default Region',
+        ]);
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $channel = Channel::create([
+            'channel_code' => 'C1',
+            'name' => 'Default Channel',
+            'region_id' => $region->id,
+        ]);
+
+        User::create([
+            'username' => 'admin',
+            'name' => 'Administrator',
+            'role' => 'admin',
+            'password' => bcrypt('password'),
+        ]);
+
+        User::create([
+            'username' => 'manager',
+            'name' => 'Manager',
+            'role' => 'manager',
+            'region_id' => $region->id,
+            'channel_id' => $channel->id,
+            'password' => bcrypt('password'),
         ]);
     }
 }

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -26,6 +26,7 @@ Route::prefix('v1')->group(function () {
         Route::apiResource('periods', ActiveMonthYearController::class);
         Route::patch('periods/{year}/{month}', [ActiveMonthYearController::class, 'patchYearMonth']);
         Route::apiResource('targets', SalesTargetController::class);
+        Route::post('targets/bulk', [SalesTargetController::class, 'bulk']);
 
         Route::get('/deps/channels', [DependencyController::class, 'channels']);
         Route::get('/deps/salesmen', [DependencyController::class, 'salesmen']);


### PR DESCRIPTION
## Summary
- create DatabaseSeeder with sample admin and manager
- add region relation to channels table
- update user factory for new user fields
- add POST `/api/v1/targets/bulk` for upsert

## Testing
- `php artisan migrate:fresh --seed`
- `php artisan test --testsuite=Feature --filter=ExampleTest`


------
https://chatgpt.com/codex/tasks/task_e_68899866e0648328abd93672c66493f7