### PR TITLE
Implement API throttling

### DIFF
--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -13,7 +13,7 @@ use App\Http\Controllers\Api\V1\DependencyController;
 use App\Http\Controllers\Api\V1\ReportController;
 use App\Http\Controllers\Api\V1\ImportController;
 
-Route::prefix('v1')->group(function () {
+Route::prefix('v1')->middleware('throttle:60,1')->group(function () {
     Route::get('/auth/me', [AuthController::class, 'me']);
     Route::post('/auth/login', [AuthController::class, 'login']);
     Route::post('/auth/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
## Summary
- add rate limit to `/api/v1` routes

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6889a724a5388328aa2e5193abac4317